### PR TITLE
Fix service not restarting on package update

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,7 +25,7 @@ class puppetwebhook::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
-    require    => [
+    subscribe  => [
       Package['puppet_webhook'],
       Systemd::Unit_file['puppet_webhook.service'],
     ],

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -16,7 +16,7 @@ describe 'puppetwebhook::service' do
           enable: true,
           hasstatus: true,
           hasrestart: true,
-        ).that_requires(['Package[puppet_webhook]', 'Systemd::Unit_file[puppet_webhook.service]'])
+        ).that_subscribes_to(['Package[puppet_webhook]', 'Systemd::Unit_file[puppet_webhook.service]'])
       }
     end
   end


### PR DESCRIPTION
Now that it's possible to set `$pkg_version`, it's even more useful to
have the service restart if the package is upgraded.
