### PR TITLE
tests: remove ruby 2.4.4 during Beaker acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -35,7 +35,7 @@ appveyor.yml:
   delete: true
 .travis.yml:
   docker_defaults:
-    rvm: 2.4.4
+    rvm: 2.5.1
     sudo: required
     dist: trusty
     services: docker
@@ -48,7 +48,6 @@ appveyor.yml:
       options:
         bundler_args: '--without release'
         env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
-        rvm: 2.5.1
     - set: ubuntu1604-64{hypervisor=docker}
       options:
         bundler_args: '--without release'
@@ -56,7 +55,6 @@ appveyor.yml:
       options:
         bundler_args: '--without release'
         env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
-        rvm: 2.5.1
     - set: centos7-64{hypervisor=docker}
       options:
         bundler_args: '--without release'
@@ -64,7 +62,6 @@ appveyor.yml:
       options:
         bundler_args: '--without release'
         env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
-        rvm: 2.5.1
     - set: debian9-64{hypervisor=docker}
       options:
         bundler_args: '--without release'
@@ -72,7 +69,6 @@ appveyor.yml:
       options:
         bundler_args: '--without release'
         env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
-        rvm: 2.5.1
     - set: debian8-64{hypervisor=docker}
       options:
         bundler_args: '--without release'
@@ -80,7 +76,6 @@ appveyor.yml:
       options:
         bundler_args: '--without release'
         env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
-        rvm: 2.5.1
   includes:
     - env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
       rvm: 2.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       bundler_args: --without release
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=ubuntu1804-64{hypervisor=docker} BEAKER_TESTMODE=apply
-      rvm: 2.4.4
+      rvm: 2.5.1
       script: bundle exec rake beaker
       services: docker
       sudo: required
@@ -40,7 +40,7 @@ matrix:
       bundler_args: --without release
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=ubuntu1604-64{hypervisor=docker} BEAKER_TESTMODE=apply
-      rvm: 2.4.4
+      rvm: 2.5.1
       script: bundle exec rake beaker
       services: docker
       sudo: required
@@ -56,7 +56,7 @@ matrix:
       bundler_args: --without release
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos7-64{hypervisor=docker} BEAKER_TESTMODE=apply
-      rvm: 2.4.4
+      rvm: 2.5.1
       script: bundle exec rake beaker
       services: docker
       sudo: required
@@ -72,7 +72,7 @@ matrix:
       bundler_args: --without release
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=debian9-64{hypervisor=docker} BEAKER_TESTMODE=apply
-      rvm: 2.4.4
+      rvm: 2.5.1
       script: bundle exec rake beaker
       services: docker
       sudo: required
@@ -88,7 +88,7 @@ matrix:
       bundler_args: --without release
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=debian8-64{hypervisor=docker} BEAKER_TESTMODE=apply
-      rvm: 2.4.4
+      rvm: 2.5.1
       script: bundle exec rake beaker
       services: docker
       sudo: required


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

the CI is with the following message : 
```
Error: /Stage[main]/Puppetwebhook::Install/Package[puppet_webhook]/ensure: change from 'absent' to 'present' failed: Execution of  '/opt/puppetlabs/puppet/bin/gem install --no-document puppet_webhook' returned 1: ERROR:  Error installing puppet_webhook:
sidekiq requires Ruby version >= 2.5.0.
```

<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
