### PR TITLE
puppet/redis: Allow 7.x

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,7 +1,7 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
-  install_module_from_forge_on(host, 'puppet-redis', '>= 6.1.0 < 7.0.0')
+  install_module_from_forge_on(host, 'puppet-redis', '>= 6.1.0 < 8.0.0')
   case fact_on(host, 'os.family')
   when 'Debian'
     install_module_from_forge_on(host, 'puppetlabs-apt', '>= 8.0.0 < 9.0.0')


### PR DESCRIPTION
also contains:
* https://github.com/voxpupuli/puppet-puppetwebhook/pull/41
* https://github.com/voxpupuli/puppet-puppetwebhook/pull/40

Requires:
* https://github.com/voxpupuli/puppet-redis/pull/397